### PR TITLE
Make limit and offset optional in 'find_<obj>' functions

### DIFF
--- a/wysteria/search.py
+++ b/wysteria/search.py
@@ -98,7 +98,7 @@ class Search(object):
             self._conn.find_collections, limit, offset
         )
 
-    def find_items(self, limit, offset):
+    def find_items(self, limit=DEFAULT_QUERY_LIMIT, offset=0):
         """Run the built query and return matching items
 
         Args:
@@ -113,7 +113,7 @@ class Search(object):
         """
         return self._generic_run_query(self._conn.find_items, limit, offset)
 
-    def find_versions(self, limit, offset):
+    def find_versions(self, limit=DEFAULT_QUERY_LIMIT, offset=0):
         """Run the built query and return matching versions
 
         Args:
@@ -128,7 +128,7 @@ class Search(object):
         """
         return self._generic_run_query(self._conn.find_versions, limit, offset)
 
-    def find_resources(self, limit, offset):
+    def find_resources(self, limit=DEFAULT_QUERY_LIMIT, offset=0):
         """Run the built query and return matching resources
 
         Args:
@@ -143,7 +143,7 @@ class Search(object):
         """
         return self._generic_run_query(self._conn.find_resources, limit, offset)
 
-    def find_links(self, limit, offset):
+    def find_links(self, limit=DEFAULT_QUERY_LIMIT, offset=0):
         """Run the built query and return matching links
 
         Args:


### PR DESCRIPTION
Er, small oversight - somehow I added the limit, and offset as optional params of only the collection :( 
```
> python ./03/main.py 
Items of type 'tree' and variant 'oak'
{'facets': {u'variant': u'oak', u'itemtype': u'tree', u'collection': u'tiles'}, 'variant': u'oak', 'itemtype': u'tree', 'parent': u'596c5f1be138230a29d41f52', 'id': u'596c5f1be138230a29d41f53'}
items of type tree and variant oak or pine
{'facets': {u'variant': u'oak', u'itemtype': u'tree', u'collection': u'tiles'}, 'variant': u'oak', 'itemtype': u'tree', 'parent': u'596c5f1be138230a29d41f52', 'id': u'596c5f1be138230a29d41f53'}
{'facets': {u'variant': u'pine', u'itemtype': u'tree', u'collection': u'tiles'}, 'variant': u'pine', 'itemtype': u'tree', 'parent': u'596c5f1be138230a29d41f52', 'id': u'596c5f1be138230a29d41f5b'}
```